### PR TITLE
docs: add live trading slippage configuration and troubleshooting

### DIFF
--- a/docs/docs/guides/quickstart.md
+++ b/docs/docs/guides/quickstart.md
@@ -378,6 +378,45 @@ BART_GOPHER_CODE=gopher_your-key-here
 TRADER_PRIVATE_KEY=your-private-key-here
 ```
 
+### traders.yaml Configuration Reference
+
+The `traders.yaml` file configures your live trading parameters:
+
+```yaml
+traders:
+  - id: "my-trader"              # Unique trader identifier
+    private_key_env: "HL_KEY"    # Env var containing Hyperliquid private key
+    capital: 1000.0              # Capital allocation in USD
+    asset: "BTC"                 # Trading asset
+    model_id: "qwen/qwen3-vl-8b-instruct"  # LLM model for decisions
+    eval_interval: 15m           # How often to evaluate positions
+    leverage: 10                 # Position leverage
+    slippage_bps: 25             # Slippage tolerance in basis points
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | string | required | Unique trader identifier |
+| `private_key_env` | string | required | Environment variable containing Hyperliquid private key |
+| `capital` | float | 1000.0 | Capital allocation in USD |
+| `asset` | string | required | Trading asset (e.g., "BTC", "TAO") |
+| `model_id` | string | qwen/qwen3-vl-8b-instruct | LLM model for trading decisions |
+| `eval_interval` | duration | 5m | How often to evaluate positions |
+| `leverage` | float | 10.0 | Position leverage |
+| `slippage_bps` | float | 25.0 | Slippage tolerance in basis points (1 bps = 0.01%) |
+
+**Slippage Configuration:**
+
+The `slippage_bps` setting controls how much price buffer is added to IOC orders to ensure fills:
+
+| Asset Liquidity | Recommended slippage_bps |
+|-----------------|-------------------------|
+| High (BTC, ETH) | 10-25 |
+| Medium (SOL, AVAX) | 25-35 |
+| Low (TAO, smaller caps) | 35-50 |
+
+Lower values give tighter fills but higher rejection risk on volatile/illiquid assets. The system also uses adaptive slippage (at least 2x the current spread) and retries with escalating slippage if orders fail.
+
 ### 4. Paper Trading (Testnet)
 
 Test your strategy without risking real funds:

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -272,6 +272,57 @@ The binary isn't in your PATH.
 2. Quotes are correct (single quotes for special characters)
 3. No extra spaces
 
+## Live Trading Issues
+
+### "Order could not immediately match against any resting orders"
+
+This error occurs when an IOC (Immediate-or-Cancel) order can't fill because the limit price is too tight relative to the current orderbook.
+
+**Cause:** The slippage buffer is smaller than the asset's bid-ask spread, or the price moved between BBO fetch and order placement.
+
+**Solutions:**
+
+1. **Increase slippage in traders.yaml:**
+   ```yaml
+   traders:
+     - id: "my-trader"
+       slippage_bps: 35  # Increase from default 25
+       # ... other settings
+   ```
+
+2. **Use higher slippage for illiquid assets:**
+
+   | Asset Liquidity | Recommended slippage_bps |
+   |-----------------|-------------------------|
+   | High (BTC, ETH) | 10-25 |
+   | Medium (SOL, AVAX) | 25-35 |
+   | Low (TAO, smaller caps) | 35-50 |
+
+3. **Check the spread:** The log shows the BBO spread in basis points. Your slippage should be at least 2x the spread. The system does this automatically, but you may need higher values during volatile periods.
+
+**Note:** As of v0.2.x, the system uses adaptive slippage (automatically uses at least 2x the current spread) and retries failed orders with +10 bps slippage up to 3 times.
+
+### Order not filling / partial fills
+
+**Cause:** Insufficient liquidity at your price level.
+
+**Solutions:**
+
+1. Reduce position size
+2. Increase slippage tolerance (`slippage_bps` in traders.yaml)
+3. Trade more liquid assets
+4. Avoid trading during low-volume periods
+
+### Position opened but TP/SL orders failed
+
+**Cause:** The take-profit or stop-loss trigger orders were rejected by Hyperliquid.
+
+**Solutions:**
+
+1. Check that TP/SL prices are valid (TP above entry for longs, below for shorts)
+2. Verify the position size meets minimum requirements for trigger orders
+3. The position is still open - you can manually manage it on Hyperliquid
+
 ## Getting Help
 
 If you can't resolve your issue:


### PR DESCRIPTION
## Summary

- Add `traders.yaml` configuration reference to quickstart guide
- Document `slippage_bps` setting with recommended values per asset liquidity
- Add troubleshooting section for IOC order failures
- Document adaptive slippage and retry behavior

## Changes

### quickstart.md
- New section: "traders.yaml Configuration Reference"
- Table documenting all trader config fields
- Slippage recommendations by asset liquidity

### troubleshooting.md
- New section: "Live Trading Issues"
- Troubleshooting for "Order could not immediately match" error
- Troubleshooting for partial fills and TP/SL failures

## Test plan

- [ ] Verify markdown renders correctly on docs site
- [ ] Check table formatting
- [ ] Verify links work