### PR TITLE
fix(docs): add explicit slugs to CLI command pages

### DIFF
--- a/docs/docs/installation/cli/assets.md
+++ b/docs/docs/installation/cli/assets.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 10
+slug: /installation/cli/assets
 ---
 
 # assets

--- a/docs/docs/installation/cli/backtest.md
+++ b/docs/docs/installation/cli/backtest.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /installation/cli/backtest
 ---
 
 # backtest

--- a/docs/docs/installation/cli/coverage.md
+++ b/docs/docs/installation/cli/coverage.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+slug: /installation/cli/coverage
 ---
 
 # coverage

--- a/docs/docs/installation/cli/evolve.md
+++ b/docs/docs/installation/cli/evolve.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+slug: /installation/cli/evolve
 ---
 
 # evolve

--- a/docs/docs/installation/cli/history.md
+++ b/docs/docs/installation/cli/history.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+slug: /installation/cli/history
 ---
 
 # history

--- a/docs/docs/installation/cli/live.md
+++ b/docs/docs/installation/cli/live.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+slug: /installation/cli/live
 ---
 
 # live

--- a/docs/docs/installation/cli/montecarlo.md
+++ b/docs/docs/installation/cli/montecarlo.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+slug: /installation/cli/montecarlo
 ---
 
 # montecarlo

--- a/docs/docs/installation/cli/setup.md
+++ b/docs/docs/installation/cli/setup.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /installation/cli/setup
 ---
 
 # setup

--- a/docs/docs/installation/cli/trades.md
+++ b/docs/docs/installation/cli/trades.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+slug: /installation/cli/trades
 ---
 
 # trades


### PR DESCRIPTION
## Summary

Fixes broken links in the CLI overview page.

The relative links were resolving to `/installation/*` instead of `/installation/cli/*` because the overview page uses a custom slug (`slug: /installation/cli`).

Added explicit slugs to all CLI command pages:
- setup → `/installation/cli/setup`
- backtest → `/installation/cli/backtest`
- montecarlo → `/installation/cli/montecarlo`
- evolve → `/installation/cli/evolve`
- live → `/installation/cli/live`
- trades → `/installation/cli/trades`
- history → `/installation/cli/history`
- coverage → `/installation/cli/coverage`
- assets → `/installation/cli/assets`

## Test Plan

- [ ] Docs build passes without broken link errors